### PR TITLE
Limit futures requirement to Python2.7

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Release History
 ===============
 
+v0.19.1
+-------
+
+**Disclaimer**
+
+All releases in the v0.x.x series are subject to breaking changes from one version to another. After the release of v1.0.0, this project will be subject to `semantic versioning <http://semver.org/>`_.
+
+**Bug Fixes**
+
+* Changed setup to only require ``futures`` for Python2.7 to avoid installing it unnecessarily; the pinned version breaks during pip install for Python3.8.
+
 v0.19.0
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="proknow",
-    version="0.19.0",
+    version="0.19.1",
     author="ProKnow",
     author_email="support@proknow.com",
     description="Python library for the ProKnow API.",
@@ -23,6 +23,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=['six', 'requests>=2.18.0', 'futures'],
+    install_requires=['six', 'requests>=2.18.0', 'futures; python_version == "2.7"'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
 )


### PR DESCRIPTION
Minor change to requirement syntax to only require the ``futures`` package for Python 2.7 to avoid unnecessary errors in installing ProKnow SDK for Python3.